### PR TITLE
Url typo fixing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ chdir(dirname(__DIR__));
 define('ZF_CLASS_CACHE', 'data/cache/classes.php.cache'); if (file_exists(ZF_CLASS_CACHE)) require_once ZF_CLASS_CACHE;
 ```
 
-- In your browser, go to http://yourapp/?EDPSUPERLUMINAL\_CACHE to build the initial
+- In your browser, go to http://yourapp/?EDPSUPERLUMINAL_CACHE to build the initial
   class. You should do this for any page that is (a) dependency heavy, and/or
   (b) every page with a different dependency graph. Each call will append to
   the cache with any newly discovered classes. **REQUESTS WHERE YOU ARE


### PR DESCRIPTION
Update of url from 
`http://yourapp/?EDPSUPERLUMINAL\_CACHE`  
to 
`http://yourapp/?EDPSUPERLUMINAL_CACHE`
as per code base.